### PR TITLE
Feature/data points attach to zone and plants

### DIFF
--- a/packages/core/src/events/data-points.event.ts
+++ b/packages/core/src/events/data-points.event.ts
@@ -1,0 +1,17 @@
+import { IDataPoint } from '../models/data-point';
+
+export enum DataPointEvents {
+  DESTROYED = 'DATA-POINT__DESTROYED',
+  CREATED = 'DATA-POINT__CREATED',
+  UPDATED = 'DATA-POINT__UPDATED',
+  READ = 'DATA-POINT__READ',
+}
+
+export const DataPointCreatedEvent = (dataPoint: IDataPoint) => ({
+  type: DataPointEvents.CREATED,
+  payload: { dataPoint },
+});
+export const DataPointDestroyedEvent = (dataPointId: string) => ({
+  type: DataPointEvents.DESTROYED,
+  payload: { dataPointId },
+});

--- a/packages/core/src/services/__tests__/plant.service.spec.ts
+++ b/packages/core/src/services/__tests__/plant.service.spec.ts
@@ -1,7 +1,9 @@
 import { IDatabase, makeInMemoryDb } from '@mdn-seed/db';
 import { makePlantService } from '../plant.service';
 import { IPlant } from '../../models/plant';
-import { MOCK_PLANT } from '../../tests/helpers';
+import { MOCK_PLANT, MOCK_DATA_POINT } from '../../tests/helpers';
+import { makeDataPoint, DataPointType } from '../../models/data-point';
+import { Unit } from '../../models/zone';
 
 describe('Service: Plant', () => {
   let database: IDatabase;
@@ -16,5 +18,61 @@ describe('Service: Plant', () => {
     expect(actual.id).toBeTruthy();
     const persisted = await plantService.findById(actual.id);
     expect(persisted).toEqual(actual);
+  });
+
+  describe('addDataPointToPlant', () => {
+    it('adds a data-point that the plant did not have previously', async () => {
+      const plantService = makePlantService({ database });
+      const plant = await plantService.create(MOCK_PLANT);
+      expect(plant.dataPoints.length).toBe(0);
+      const dataPoint = makeDataPoint({
+        ...MOCK_DATA_POINT,
+        plantId: plant.id,
+      });
+      const updatedPlant = await plantService.addDataPoint(plant, dataPoint);
+      expect(updatedPlant.dataPoints.length).toBe(1);
+    });
+
+    it('replaces a data-point of the same type', async () => {
+      const plantService = makePlantService({ database });
+      const plant = await plantService.create(MOCK_PLANT);
+      expect(plant.dataPoints.length).toBe(0);
+      const dataPoint = makeDataPoint({
+        ...MOCK_DATA_POINT,
+        plantId: plant.id,
+      });
+      await plantService.addDataPoint(plant, dataPoint);
+      const updatedPlant = await plantService.addDataPoint(plant, dataPoint);
+      expect(updatedPlant.dataPoints.length).toBe(1);
+    });
+
+    it('only replaces a data-point of the same type if the new one is more recent (timestamp)', async () => {
+      const plantService = makePlantService({ database });
+      const plant = await plantService.create(MOCK_PLANT);
+      expect(plant.dataPoints.length).toBe(0);
+      const dataPoint = makeDataPoint({
+        ...MOCK_DATA_POINT,
+        timestamp: 10,
+        plantId: plant.id,
+      });
+
+      const dataPoint2 = makeDataPoint({
+        ...MOCK_DATA_POINT,
+        timestamp: 20,
+        plantId: plant.id,
+      });
+
+      const dataPoint3 = makeDataPoint({
+        ...MOCK_DATA_POINT,
+        timestamp: 1,
+        plantId: plant.id,
+      });
+      await plantService.addDataPoint(plant, dataPoint);
+      await plantService.addDataPoint(plant, dataPoint2);
+      await plantService.addDataPoint(plant, dataPoint3);
+      const updatedPlant = await plantService.addDataPoint(plant, dataPoint2);
+      expect(updatedPlant.dataPoints.length).toBe(1);
+      expect(updatedPlant.dataPoints[0]).toEqual(dataPoint2);
+    });
   });
 });

--- a/packages/core/src/services/service.interface.ts
+++ b/packages/core/src/services/service.interface.ts
@@ -1,3 +1,5 @@
+import { IDataPoint } from '../models/data-point';
+
 export interface Service<T, R> {
   create: (item: T) => Promise<R>;
   update: (item: Partial<R>) => Promise<R>;
@@ -18,4 +20,8 @@ export enum ServiceErrors {
   NotFound = 'NotFound',
   Duplicate = 'Duplicate',
   MissingData = 'MissingData',
+}
+
+export interface HasDataPoints<T> {
+  addDataPoint: (entity: T, dataPoint: IDataPoint) => Promise<T>;
 }

--- a/packages/core/src/services/zone.service.ts
+++ b/packages/core/src/services/zone.service.ts
@@ -78,7 +78,9 @@ export const makeZoneService = ({
         existingIndex === -1
           ? [...zone.dataPoints, dataPoint]
           : zone.dataPoints.map((dp) =>
-              dp.type === dataPoint.type ? dataPoint : dp
+              dp.type !== dataPoint.type && dp.timestamp > dataPoint.timestamp
+                ? dp
+                : dataPoint
             ),
     });
     console.log({ newZone });

--- a/packages/core/src/services/zone.service.ts
+++ b/packages/core/src/services/zone.service.ts
@@ -1,9 +1,10 @@
 import { IDatabase } from '@mdn-seed/db';
 import { serviceErrorFactory } from '../uses/core/helpers/handle-error';
 import { IZoneData, makeZone, IZone } from '../models/zone';
-import { Service } from './service.interface';
+import { Service, HasDataPoints } from './service.interface';
+import { IDataPoint } from '../models/data-point';
 
-export type ZoneService = Service<IZoneData, IZone>;
+export type ZoneService = Service<IZoneData, IZone> & HasDataPoints<IZone>;
 
 export const makeZoneService = ({
   database,
@@ -17,6 +18,7 @@ export const makeZoneService = ({
     findById,
     findBy,
     destroy,
+    addDataPoint,
   });
 
   async function create(zoneData: IZoneData): Promise<IZone> {
@@ -36,11 +38,15 @@ export const makeZoneService = ({
     return results.map(documentToObj);
   }
 
-  async function update(zoneData: Partial<IZone>): Promise<IZone> {
+  async function update(
+    zoneData: Partial<IZone>,
+    options = { merge: true }
+  ): Promise<IZone> {
+    const { merge } = options;
     await database.collection('zones');
     const current = await database.findById(zoneData.id);
     const newZone = makeZone({ ...current, ...zoneData });
-    const result = await database.update(newZone);
+    const result = await database.update(newZone, { merge });
     return documentToObj(result);
   }
 
@@ -60,6 +66,24 @@ export const makeZoneService = ({
     await database.collection('zones');
     const results = await database.where(property, '==', value);
     return results.map(documentToObj);
+  }
+
+  async function addDataPoint(zone: IZone, dataPoint: IDataPoint) {
+    const existingIndex = zone.dataPoints.findIndex(
+      (dp) => dp.type === dataPoint.type
+    );
+    const newZone = makeZone({
+      ...zone,
+      dataPoints:
+        existingIndex === -1
+          ? [...zone.dataPoints, dataPoint]
+          : zone.dataPoints.map((dp) =>
+              dp.type === dataPoint.type ? dataPoint : dp
+            ),
+    });
+    console.log({ newZone });
+    const result = await database.update(newZone, { merge: false });
+    return documentToObj(result);
   }
 
   function documentToObj(zone: IZoneData): IZone {

--- a/packages/core/src/tests/helpers.ts
+++ b/packages/core/src/tests/helpers.ts
@@ -1,5 +1,6 @@
 import { Unit } from '../models/zone';
 import { IPlantData, PlantStatus } from '../models/plant';
+import { DataPointType, IDataPoint } from '../models/data-point';
 
 export const MOCK_ZONE = {
   name: 'Hoth',
@@ -24,4 +25,11 @@ export const MOCK_PLANT_2: IPlantData = {
   strain: 'Outdoor',
   name: 'Freebie',
   dataPoints: [],
+};
+
+export const MOCK_DATA_POINT: IDataPoint = {
+  type: DataPointType.TEMPERATURE,
+  timestamp: Date.now(),
+  dataUnit: 'C',
+  dataValue: 15,
 };

--- a/packages/core/src/uses/endpoints/data-points.endpoint.ts
+++ b/packages/core/src/uses/endpoints/data-points.endpoint.ts
@@ -17,6 +17,7 @@ import { MethodNotSupportedError } from '../../helpers/errors';
 import { PlantEvents } from '../../events/plant.events';
 import { events } from '../../events/events';
 import { ZoneEvents } from '../../events/zone.events';
+import { DataPointCreatedEvent } from '../../events/data-points.event';
 
 export const makeDataPointsEndpointHandler = ({
   dataPointService,
@@ -74,6 +75,7 @@ export const makeDataPointsEndpointHandler = ({
 
       // Save DP
       const dp = await dataPointService.create(dataPoint);
+      events.dispatch(DataPointCreatedEvent(dp));
       return handleSuccess(dp, CoreResponseStatus.CreatedSuccess);
     } catch (error) {
       return Promise.reject(handleServiceError(error));

--- a/packages/db/src/provider/firebase.database.ts
+++ b/packages/db/src/provider/firebase.database.ts
@@ -1,7 +1,6 @@
 import * as firebase from 'firebase';
 import {
   DocumentNotFoundError,
-  UniqueConstraintError,
   RequiredParameterError,
 } from '@mdn-seed/core/src/helpers/errors';
 import { IDatabase } from '../types/database.interface';
@@ -71,9 +70,10 @@ export default function makeFirebaseDatabase({
     return { ...data, id: docRef.id };
   }
 
-  async function update(item: any) {
+  async function update(item: any, options = { merge: true }) {
+    const { merge } = options;
     const docRef = await database.collection(currentCollection).doc(item.id);
-    docRef.set({ ...item }, { merge: true });
+    docRef.set({ ...item }, { merge });
     const updated = (await docRef.get()).data();
     return { ...updated, id: docRef.id };
   }

--- a/packages/db/src/types/database.interface.ts
+++ b/packages/db/src/types/database.interface.ts
@@ -1,3 +1,7 @@
+export interface UpdateOptions {
+  merge?: boolean;
+}
+
 export interface IDatabase {
   // findById: (id: string) => Promise<R>;
   // insert: (item: T) => Promise<R>;
@@ -11,7 +15,7 @@ export interface IDatabase {
   insert: (item: any) => Promise<any>;
   list: () => Promise<Array<any>>;
   destroy: (id?: string) => Promise<boolean>;
-  update: (item: any) => Promise<any>;
+  update: (item: any, options?: any) => Promise<any>;
   where: (property: string, operator: any, value: any) => Promise<Array<any>>;
   collection(table: string): void;
 }

--- a/packages/rest/src/tests/api/postman.json
+++ b/packages/rest/src/tests/api/postman.json
@@ -338,6 +338,11 @@
 								"exec": [
 									"pm.test(\"Status code is 200\", function () {",
 									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Have 1 DataPoint on Plant Document\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData.dataPoints.length).to.eql(1);",
 									"});"
 								],
 								"type": "text/javascript"

--- a/packages/rest/src/tests/api/postman.json
+++ b/packages/rest/src/tests/api/postman.json
@@ -696,7 +696,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"zoneId\": \"{{zoneId}}\",\n    \"type\": \"TEMPERATURE\",\n    \"dataValue\": \"23.6\",\n    \"dataUnit\": \"Celcius\",\n    \"timestamp\": \"1594042336\"\n}",
+							"raw": "{\n    \"zoneId\": \"{{zoneId}}\",\n    \"type\": \"TEMPERATURE\",\n    \"dataValue\": \"33.6\",\n    \"dataUnit\": \"Celcius\",\n    \"timestamp\": \"1594042336\"\n}",
 							"options": {
 								"raw": {
 									"language": "json"

--- a/packages/rest/src/tests/api/postman.json
+++ b/packages/rest/src/tests/api/postman.json
@@ -794,6 +794,11 @@
 								"exec": [
 									"pm.test(\"Status code is 200\", function () {",
 									"    pm.response.to.have.status(200);",
+									"});",
+									"",
+									"pm.test(\"Have 1 DataPoint on Zone Document\", function () {",
+									"    var jsonData = pm.response.json();",
+									"    pm.expect(jsonData.dataPoints.length).to.eql(1);",
 									"});"
 								],
 								"type": "text/javascript"


### PR DESCRIPTION
I wanted to update the Zone/Plant document when a new DataPoint is created in the backend. it should only one of each type, and it should only keep the latest (most recent timestamp)